### PR TITLE
Allow email to be used as the customer identifier

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -92,6 +92,14 @@ class Client
     {
         $this->appKey = $appKey;
     }
+    
+     /**
+     * @param string $siteId
+     */
+    public function setSiteId(string $siteId): void
+    {
+        $this->siteId = $siteId;
+    }
 
     /**
      * Set default client

--- a/src/Endpoint/Customers.php
+++ b/src/Endpoint/Customers.php
@@ -54,12 +54,17 @@ class Customers extends Base
             $this->mockException('User id or email is required!', 'PUT');
         } // @codeCoverageIgnore
 
+        $this->setCustomerPathWithIdentifier($options);
+
+        return $this->client->put($path, $options);
+    }
+    
+    private function setCustomerPathWithIdentifier(array $options){
+        
         $customerIdentifierProperty = isset($options['id']) ? 'id' : 'email';
 
         $path = $this->customerPath($options[$customerIdentifierProperty]);
         unset($options[$customerIdentifierProperty]);
-
-        return $this->client->put($path, $options);
     }
 
     /**

--- a/src/Endpoint/Customers.php
+++ b/src/Endpoint/Customers.php
@@ -50,16 +50,14 @@ class Customers extends Base
      */
     public function add(array $options)
     {
-        if (!isset($options['id'])) {
-            $this->mockException('User id is required!', 'PUT');
+        if (!isset($options['id']) && !isset($options['email'])) {
+            $this->mockException('User id or email is required!', 'PUT');
         } // @codeCoverageIgnore
 
-        if (!isset($options['email'])) {
-            $this->mockException('Email is required!', 'PUT');
-        } // @codeCoverageIgnore
+        $customerIdentifierProperty = isset($options['id']) ? 'id' : 'email';
 
-        $path = $this->customerPath($options['id']);
-        unset($options['id']);
+        $path = $this->customerPath($options[$customerIdentifierProperty]);
+        unset($options[$customerIdentifierProperty]);
 
         return $this->client->put($path, $options);
     }

--- a/src/Endpoint/Customers.php
+++ b/src/Endpoint/Customers.php
@@ -32,7 +32,7 @@ class Customers extends Base
             $this->mockException('User id or email is required!', 'POST');
         } // @codeCoverageIgnore
 
-        $this->setCustomerPathWithIdentifier($options);
+        $path = $this->setCustomerPathWithIdentifier($options);
 
         return $this->client->post($path."/events", $options);
     }
@@ -49,7 +49,7 @@ class Customers extends Base
             $this->mockException('User id or email is required!', 'PUT');
         } // @codeCoverageIgnore
 
-        $this->setCustomerPathWithIdentifier($options);
+        $path = $this->setCustomerPathWithIdentifier($options);
 
         return $this->client->put($path, $options);
     }
@@ -68,7 +68,7 @@ class Customers extends Base
             $this->mockException('User id or email is required!', 'DELETE');
         } // @codeCoverageIgnore
 
-        $this->setCustomerPathWithIdentifier($options);
+        $path = $this->setCustomerPathWithIdentifier($options);
 
         return $this->client->delete($path, []);
     }
@@ -131,7 +131,7 @@ class Customers extends Base
             $this->mockException('User id or email is required!', 'GET');
         } // @codeCoverageIgnore
 
-        $this->setCustomerPathWithIdentifier($options);
+        $path = $this->setCustomerPathWithIdentifier($options);
 
         return $this->client->get($path, $options);
     }
@@ -148,7 +148,7 @@ class Customers extends Base
             $this->mockException('User id or email is required!', 'GET');
         } // @codeCoverageIgnore
 
-        $this->setCustomerPathWithIdentifier($options);
+        $path = $this->setCustomerPathWithIdentifier($options);
 
         return $this->client->get($path, $options);
     }
@@ -165,7 +165,8 @@ class Customers extends Base
             $this->mockException('User id or email is required!', 'GET');
         } // @codeCoverageIgnore
 
-        $this->setCustomerPathWithIdentifier($options);
+        $path = $this->setCustomerPathWithIdentifier($options);
+        
         return $this->client->get($path, $options);
     }
 
@@ -181,7 +182,7 @@ class Customers extends Base
             $this->mockException('User id or email is required!', 'GET');
         } // @codeCoverageIgnore
 
-        $this->setCustomerPathWithIdentifier($options);
+        $path = $this->setCustomerPathWithIdentifier($options);
 
         return $this->client->get($path, $options);
     }
@@ -198,7 +199,7 @@ class Customers extends Base
             $this->mockException('User id or email is required!', 'GET');
         } // @codeCoverageIgnore
 
-        $this->setCustomerPathWithIdentifier($options);
+        $path = $this->setCustomerPathWithIdentifier($options);
         
         return $this->client->post($path, $options);
     }
@@ -215,7 +216,7 @@ class Customers extends Base
             $this->mockException('User id or email is required!', 'GET');
         } // @codeCoverageIgnore
 
-        $this->setCustomerPathWithIdentifier($options);
+        $path = $this->setCustomerPathWithIdentifier($options);
 
         return $this->client->post($path, $options);
     }
@@ -232,5 +233,7 @@ class Customers extends Base
 
         $path = $this->customerPath($options[$customerIdentifierProperty]);
         unset($options[$customerIdentifierProperty]);
+        
+        return $path;
     }
 }

--- a/src/Endpoint/Customers.php
+++ b/src/Endpoint/Customers.php
@@ -28,16 +28,11 @@ class Customers extends Base
      */
     public function event(array $options)
     {
-        if (!isset($options['id'])) {
-            $this->mockException('User id is required!', 'POST');
+        if (!isset($options['id']) && !isset($options['email'])) {
+            $this->mockException('User id or email is required!', 'PUT');
         } // @codeCoverageIgnore
 
-        if (!isset($options['name'])) {
-            $this->mockException('Name is required!', 'POST');
-        } // @codeCoverageIgnore
-
-        $path = $this->customerPath($options['id']);
-        unset($options['id']);
+        $this->setCustomerPathWithIdentifier($options);
 
         return $this->client->post($path."/events", $options);
     }
@@ -59,13 +54,7 @@ class Customers extends Base
         return $this->client->put($path, $options);
     }
     
-    private function setCustomerPathWithIdentifier(array $options){
-        
-        $customerIdentifierProperty = isset($options['id']) ? 'id' : 'email';
-
-        $path = $this->customerPath($options[$customerIdentifierProperty]);
-        unset($options[$customerIdentifierProperty]);
-    }
+    
 
     /**
      * Delete customer
@@ -75,12 +64,11 @@ class Customers extends Base
      */
     public function delete(array $options)
     {
-        if (!isset($options['id'])) {
-            $this->mockException('User id is required!', 'DELETE');
+        if (!isset($options['id']) && !isset($options['email'])) {
+            $this->mockException('User id or email is required!', 'PUT');
         } // @codeCoverageIgnore
 
-        $path = $this->customerPath($options['id']);
-        unset($options['id']);
+        $this->setCustomerPathWithIdentifier($options);
 
         return $this->client->delete($path, []);
     }
@@ -139,12 +127,11 @@ class Customers extends Base
      */
     public function attributes(array $options)
     {
-        if (!isset($options['id'])) {
-            $this->mockException('User id is required!', 'GET');
+        if (!isset($options['id']) && !isset($options['email'])) {
+            $this->mockException('User id or email is required!', 'PUT');
         } // @codeCoverageIgnore
 
-        $path = $this->customerPath($options['id'], ['attributes']);
-        unset($options['id']);
+        $this->setCustomerPathWithIdentifier($options);
 
         return $this->client->get($path, $options);
     }
@@ -157,12 +144,11 @@ class Customers extends Base
      */
     public function segments(array $options)
     {
-        if (!isset($options['id'])) {
-            $this->mockException('User id is required!', 'GET');
+        if (!isset($options['id']) && !isset($options['email'])) {
+            $this->mockException('User id or email is required!', 'PUT');
         } // @codeCoverageIgnore
 
-        $path = $this->customerPath($options['id'], ['segments']);
-        unset($options['id']);
+        $this->setCustomerPathWithIdentifier($options);
 
         return $this->client->get($path, $options);
     }
@@ -175,13 +161,11 @@ class Customers extends Base
      */
     public function messages(array $options)
     {
-        if (!isset($options['id'])) {
-            $this->mockException('User id is required!', 'GET');
+        if (!isset($options['id']) && !isset($options['email'])) {
+            $this->mockException('User id or email is required!', 'PUT');
         } // @codeCoverageIgnore
 
-        $path = $this->customerPath($options['id'], ['messages']);
-        unset($options['id']);
-
+        $this->setCustomerPathWithIdentifier($options);
         return $this->client->get($path, $options);
     }
 
@@ -193,12 +177,11 @@ class Customers extends Base
      */
     public function activities(array $options)
     {
-        if (!isset($options['id'])) {
-            $this->mockException('User id is required!', 'GET');
+       if (!isset($options['id']) && !isset($options['email'])) {
+            $this->mockException('User id or email is required!', 'PUT');
         } // @codeCoverageIgnore
 
-        $path = $this->customerPath($options['id'], ['activities']);
-        unset($options['id']);
+        $this->setCustomerPathWithIdentifier($options);
 
         return $this->client->get($path, $options);
     }
@@ -211,13 +194,12 @@ class Customers extends Base
      */
     public function suppress(array $options)
     {
-        if (!isset($options['id'])) {
-            $this->mockException('User id is required!', 'GET');
+        if (!isset($options['id']) && !isset($options['email'])) {
+            $this->mockException('User id or email is required!', 'PUT');
         } // @codeCoverageIgnore
 
-        $path = $this->customerPath($options['id'], ['suppress']);
-        unset($options['id']);
-
+        $this->setCustomerPathWithIdentifier($options);
+        
         return $this->client->post($path, $options);
     }
 
@@ -229,13 +211,26 @@ class Customers extends Base
      */
     public function unsuppress(array $options)
     {
-        if (!isset($options['id'])) {
-            $this->mockException('User id is required!', 'GET');
+       if (!isset($options['id']) && !isset($options['email'])) {
+            $this->mockException('User id or email is required!', 'PUT');
         } // @codeCoverageIgnore
 
-        $path = $this->customerPath($options['id'], ['unsuppress']);
-        unset($options['id']);
+        $this->setCustomerPathWithIdentifier($options);
 
         return $this->client->post($path, $options);
+    }
+    
+    
+     /**
+     * Set the customer path with the relevant identifier
+     * @param array $options
+     * @return void
+     */
+    private function setCustomerPathWithIdentifier(array &$options){
+        
+        $customerIdentifierProperty = isset($options['id']) ? 'id' : 'email';
+
+        $path = $this->customerPath($options[$customerIdentifierProperty]);
+        unset($options[$customerIdentifierProperty]);
     }
 }

--- a/src/Endpoint/Customers.php
+++ b/src/Endpoint/Customers.php
@@ -29,7 +29,7 @@ class Customers extends Base
     public function event(array $options)
     {
         if (!isset($options['id']) && !isset($options['email'])) {
-            $this->mockException('User id or email is required!', 'PUT');
+            $this->mockException('User id or email is required!', 'POST');
         } // @codeCoverageIgnore
 
         $this->setCustomerPathWithIdentifier($options);
@@ -65,7 +65,7 @@ class Customers extends Base
     public function delete(array $options)
     {
         if (!isset($options['id']) && !isset($options['email'])) {
-            $this->mockException('User id or email is required!', 'PUT');
+            $this->mockException('User id or email is required!', 'DELETE');
         } // @codeCoverageIgnore
 
         $this->setCustomerPathWithIdentifier($options);
@@ -128,7 +128,7 @@ class Customers extends Base
     public function attributes(array $options)
     {
         if (!isset($options['id']) && !isset($options['email'])) {
-            $this->mockException('User id or email is required!', 'PUT');
+            $this->mockException('User id or email is required!', 'GET');
         } // @codeCoverageIgnore
 
         $this->setCustomerPathWithIdentifier($options);
@@ -145,7 +145,7 @@ class Customers extends Base
     public function segments(array $options)
     {
         if (!isset($options['id']) && !isset($options['email'])) {
-            $this->mockException('User id or email is required!', 'PUT');
+            $this->mockException('User id or email is required!', 'GET');
         } // @codeCoverageIgnore
 
         $this->setCustomerPathWithIdentifier($options);
@@ -162,7 +162,7 @@ class Customers extends Base
     public function messages(array $options)
     {
         if (!isset($options['id']) && !isset($options['email'])) {
-            $this->mockException('User id or email is required!', 'PUT');
+            $this->mockException('User id or email is required!', 'GET');
         } // @codeCoverageIgnore
 
         $this->setCustomerPathWithIdentifier($options);
@@ -178,7 +178,7 @@ class Customers extends Base
     public function activities(array $options)
     {
        if (!isset($options['id']) && !isset($options['email'])) {
-            $this->mockException('User id or email is required!', 'PUT');
+            $this->mockException('User id or email is required!', 'GET');
         } // @codeCoverageIgnore
 
         $this->setCustomerPathWithIdentifier($options);
@@ -195,7 +195,7 @@ class Customers extends Base
     public function suppress(array $options)
     {
         if (!isset($options['id']) && !isset($options['email'])) {
-            $this->mockException('User id or email is required!', 'PUT');
+            $this->mockException('User id or email is required!', 'GET');
         } // @codeCoverageIgnore
 
         $this->setCustomerPathWithIdentifier($options);
@@ -212,7 +212,7 @@ class Customers extends Base
     public function unsuppress(array $options)
     {
        if (!isset($options['id']) && !isset($options['email'])) {
-            $this->mockException('User id or email is required!', 'PUT');
+            $this->mockException('User id or email is required!', 'GET');
         } // @codeCoverageIgnore
 
         $this->setCustomerPathWithIdentifier($options);


### PR DESCRIPTION
Customer.io allows you to use either ID or Email as the unique identifier in the customer API requests:
![image](https://user-images.githubusercontent.com/1628446/114491264-73e84380-9c6a-11eb-8935-47f3a13c1ede.png)

This change allows either to be used for customer calls. It is fully backwards compatible with previous releases as it first checks/uses the `id` field if it is present, if it isn't it will then fall back to `email`.

