### PR TITLE
fix: switch App API to Bearer auth (#37)

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -97,7 +97,7 @@ class Client
         $this->appKey = $appKey;
     }
 
-     /**
+    /**
      * @param string $siteId
      */
     public function setSiteId(string $siteId): void
@@ -265,7 +265,6 @@ class Client
                     'connect_timeout' => 2,
                     'timeout' => 5,
                 ];
-                break;
             default:
                 return [
                     'auth' => $this->getAuth(),

--- a/src/Client.php
+++ b/src/Client.php
@@ -256,6 +256,7 @@ class Client
     {
         switch ($endpoint) {
             case self::API_ENDPOINT_BETA:
+            case self::API_ENDPOINT:
                 return [
                     'headers' => [
                         'Authorization' => 'Bearer '.$this->getToken(),

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -50,8 +50,9 @@ class ClientTest extends TestCase
             /** @var Request $request */
             $request = $transaction['request'];
             $auth = $request->getHeaders()['Authorization'][0];
-            switch ($request->getMethod()) {
-                case 'GET':
+            switch ($request->getUri()->getHost()) {
+                case parse_url(CustomerIoClient::API_ENDPOINT_BETA, PHP_URL_HOST):
+                case parse_url(CustomerIoClient::API_ENDPOINT, PHP_URL_HOST):
                     $this->assertTrue($auth == "Bearer t");
                     break;
                 default:


### PR DESCRIPTION
```
Hi there,

We've noticed that you've used basic authentication to access the App API in the last 30 days. You will need to change the authentication method within the next 2 weeks, or calls to send triggered broadcasts or transactional messages will fail.

Beginning April 14th at 00:00 UTC we will no longer allow access to our App API through basic authentication. Instead, bearer authentication is required to utilize the API. You can find more details on this authentication scheme in our API documentation.

If you have any questions, simply reply to this email and we'll be happy to help!

Thanks!

CIO Engineering Team
```