### PR TITLE
Allow cio_id to be used as the identifier on the path

### DIFF
--- a/src/Endpoint/Customers.php
+++ b/src/Endpoint/Customers.php
@@ -27,8 +27,8 @@ class Customers extends Base
      */
     public function event(array $options)
     {
-        if (!isset($options['id']) && !isset($options['email'])) {
-            $this->mockException('User id or email is required!', 'POST');
+        if (!isset($options['id']) && !isset($options['email']) && !isset($options['cio_id'])) {
+            $this->mockException('User id, email or cio_id is required!', 'POST');
         } // @codeCoverageIgnore
 
         $path = $this->setCustomerPathWithIdentifier($options);

--- a/src/Endpoint/Customers.php
+++ b/src/Endpoint/Customers.php
@@ -227,12 +227,12 @@ class Customers extends Base
      * @return string
      */
     private function setCustomerPathWithIdentifier(array &$options): string {
-        
         $customerIdentifierProperty = isset($options['cio_id']) ? 'cio_id' : (isset($options['id']) ? 'id' : 'email');
+        $customerIdentifierPrefix = isset($options['cio_id']) ? 'cio_' : '';
 
-        $path = $this->customerPath($options[$customerIdentifierProperty]);
+        $path = $this->customerPath($customerIdentifierPrefix .$options[$customerIdentifierProperty]);
         unset($options[$customerIdentifierProperty]);
-        
+
         return $path;
     }
 }

--- a/src/Endpoint/Customers.php
+++ b/src/Endpoint/Customers.php
@@ -228,7 +228,7 @@ class Customers extends Base
      */
     private function setCustomerPathWithIdentifier(array &$options): string {
         
-        $customerIdentifierProperty = isset($options['id']) ? 'id' : 'email';
+        $customerIdentifierProperty = isset($options['cio_id']) ? 'cio_id' : (isset($options['id']) ? 'id' : 'email');
 
         $path = $this->customerPath($options[$customerIdentifierProperty]);
         unset($options[$customerIdentifierProperty]);


### PR DESCRIPTION
This is from the API Docs:

If you want to update identifiers that are already set for a person, you must reference them using their cio_id in the format cio_<cio_id_value>; attempting to update identifier values for a person without referencing them by cio_id will result in an Attribute Update Failure.