### PR TITLE
Update Region.php: PHP 8.2: ${var} string interpolation deprecated

### DIFF
--- a/src/Region.php
+++ b/src/Region.php
@@ -19,7 +19,7 @@ class Region
             case 'eu':
                 return new RegionEu();
             default:
-                throw new InvalidRegionException("Unknown region: ${region}");
+                throw new InvalidRegionException('Unknown region: ' . $region);
         }
     }
 }


### PR DESCRIPTION
https://php.watch/versions/8.2/$%7Bvar%7D-string-interpolation-deprecated