### PR TITLE
feat: add support for sms endpoint

### DIFF
--- a/src/Endpoint/Send.php
+++ b/src/Endpoint/Send.php
@@ -41,4 +41,30 @@ class Send extends Base
 
         return $this->client->post('send/email', $options);
     }
+
+    /**
+     * Send a transactional SMS
+     * @see https://docs.customer.io/integrations/api/app/#operation/sendSMS
+     * @param array $options
+     * @return mixed
+     * @throws GuzzleException
+     */
+    public function sms(array $options)
+    {
+        if (!isset($options['transactional_message_id'])) {
+            $this->mockException('SMS transactional_message_id is required!', 'POST');
+        } // @codeCoverageIgnore
+
+        if (!isset($options['identifiers'])) {
+            $this->mockException('SMS identifiers is required!', 'POST');
+        } // @codeCoverageIgnore
+
+        if (!isset($options['to'])) {
+            $this->mockException('SMS to is required!', 'POST');
+        } // @codeCoverageIgnore
+
+        $options['endpoint'] = $this->client->getRegion()->apiUri();
+
+        return $this->client->post('send/sms', $options);
+    }
 }

--- a/tests/SendTest.php
+++ b/tests/SendTest.php
@@ -111,4 +111,75 @@ class SendTest extends TestCase
             ],
         ]));
     }
+
+    public function testSendSmsWithId()
+    {
+        $stub = $this->getMockBuilder('Customerio\Client')->disableOriginalConstructor()->getMock();
+        $stub->method('post')->willReturn('foo');
+        $page = new Send($stub);
+        $this->assertEquals('foo', $page->sms([
+            'transactional_message_id' => 2,
+            'to' => '+15551234567',
+            'identifiers' => [
+                'id' => 12,
+            ],
+        ]));
+    }
+
+    public function testSendSmsWithMessageData()
+    {
+        $stub = $this->getMockBuilder('Customerio\Client')->disableOriginalConstructor()->getMock();
+        $stub->method('post')->willReturn('foo');
+        $page = new Send($stub);
+        $this->assertEquals('foo', $page->sms([
+            'transactional_message_id' => 2,
+            'to' => '+15551234567',
+            'identifiers' => [
+                'id' => 12,
+            ],
+            'message_data' => [
+                'name' => 'John Doe',
+            ],
+        ]));
+    }
+
+    public function testSendSmsMissingTransactionalMessageId()
+    {
+        $this->expectException(GuzzleException::class);
+        $stub = $this->getMockBuilder('Customerio\Client')->disableOriginalConstructor()->getMock();
+        $stub->method('post')->willReturn('foo');
+        $page = new Send($stub);
+        $this->assertEquals('foo', $page->sms([
+            'to' => '+15551234567',
+            'identifiers' => [
+                'id' => 12,
+            ],
+        ]));
+    }
+
+    public function testSendSmsMissingTo()
+    {
+        $this->expectException(GuzzleException::class);
+        $stub = $this->getMockBuilder('Customerio\Client')->disableOriginalConstructor()->getMock();
+        $stub->method('post')->willReturn('foo');
+        $page = new Send($stub);
+        $this->assertEquals('foo', $page->sms([
+            'transactional_message_id' => 2,
+            'identifiers' => [
+                'id' => 12,
+            ],
+        ]));
+    }
+
+    public function testSendSmsMissingIdentifiers()
+    {
+        $this->expectException(GuzzleException::class);
+        $stub = $this->getMockBuilder('Customerio\Client')->disableOriginalConstructor()->getMock();
+        $stub->method('post')->willReturn('foo');
+        $page = new Send($stub);
+        $this->assertEquals('foo', $page->sms([
+            'transactional_message_id' => 2,
+            'to' => '+15551234567',
+        ]));
+    }
 }


### PR DESCRIPTION
Adding support for sending sms according to this [endpoint](https://docs.customer.io/integrations/api/app/#operation/sendSMS)